### PR TITLE
Esp32 2.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,10 @@ better off on its own. Only functionalities necessary for oscilloscope to work a
 1. Copy all files in this package into Esp32_oscilloscope directory.
 2. Open Esp32_oscilloscope.ino with Arduino IDE.
 3. Find and change YOUR-STA-SSID to your WiFi SSID and YOUR-STA-PASSWORD to your WiFi password.
-4. Oscilloscope uses FAT file system so select one of FATFS partition schemas (Tools | Partition scheme | ...)
-5. Compile sketch and run it on your ESP32 for the first time. Doing this, ESP32 flash memory will be formatted with FAT file system. WARNING: every information you have stored into ESP32’s flash memory will be lost.
-6. FTP to your ESP32 (By using ftp command line utility or Windows explorer. User name and password are not required) and upload the following files into /var/www/html directory:
+4. In your Arduino IDE under Tools|Board make sure you choose "ESP32 Dev Module" or a board allowing partition schemes
+5. Oscilloscope uses FAT file system so select one of FATFS partition schemas (Arduino IDE under Tools|Partition Scheme|...)
+6. Compile sketch and run it on your ESP32 for the first time. Doing this, ESP32 flash memory will be formatted with FAT file system. WARNING: every information you have stored into ESP32’s flash memory will be lost.
+7. FTP to your ESP32 (By using ftp command line utility or Windows explorer. User name and password are not required) and upload the following files into /var/www/html directory:
 
    - android-192-osc.png,
    - apple-180-osc.png,
@@ -50,4 +51,4 @@ ftp> ls
 ftp>
 ```
 
-6. Open http://YOUR-ESP32-IP/oscilloscope.html with your browser.
+8. Open http://YOUR-ESP32-IP/oscilloscope.html with your browser.

--- a/common_functions.h
+++ b/common_functions.h
@@ -66,6 +66,17 @@
     return String (s);
   }
 
+
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(4, 4, 0) //Checks if board manager version for esp32 is  >= 2.0.0
+  String inet_ntos (esp_ip4_addr_t addr) { // equivalent of inet_ntoa
+    char s [40];
+    xSemaphoreTake (__ntosSemaphore__, portMAX_DELAY);
+      strcpy (s, inet_ntoa (addr)); 
+    xSemaphoreGive (__ntosSemaphore__);
+    return String (s);
+  }
+#endif
+
   String inet_ntos (ip4_addr_t addr) { // equivalent of inet_ntoa
     char s [40];
     xSemaphoreTake (__ntosSemaphore__, portMAX_DELAY);

--- a/oscilloscope.html
+++ b/oscilloscope.html
@@ -256,26 +256,29 @@
     </div>
 
     <hr />
-    <div class='d1'; style='height: 76px;'>
-      <div class='d2'>&nbsp;Remeber settings<br>&nbsp;<small><small>Some essential cookies will be used for this.</small></small></div>
+    <div class='d1'>
+      <div class='d2'>&nbsp;Remember settings <small><small>(uses cookies)</small></small></div>
       <div class='d3'>
         <label class='switch'><input type='checkbox' id='remember' onclick="
           saveSettings ();
         "><div class='slider round'></div></label>
       </div>
-      <div class='d3'><button class='button button2' id='startButton' onclick="
+    </div>
+
+    <hr />
+    <div class='d1'>
+      <div class='d2'><button class='button button2' id='startButton' onclick="
         saveSettings ();
         drawBackgroundAndCalculateParameters ();
         enableDisableControls (true);
         startOscilloscope ();
       ">&nbsp;START&nbsp;</button></div>
-      <div class='d5'><button class='button button3' id='stopButton' disabled onclick="
+      <div class='d2'><button class='button button3' id='stopButton' disabled onclick="
         stopOscilloscope ();
         enableDisableControls (false);
       ">&nbsp;STOP&nbsp;</button></div>
     </div>
 
-    <hr />
     <br>
 
     <canvas id='oscilloscope' width='968' height='512';></canvas></div>

--- a/webServer.hpp
+++ b/webServer.hpp
@@ -68,7 +68,12 @@
    TcpConnection since TcpCOnnection already exists at the time WebSocket is beeing created
  */
 
-  #include "hwcrypto/sha.h"       // needed for websockets support 
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(4, 4, 0) //Checks if board manager version for esp32 is  >= 2.0.0
+      #include "esp32/sha.h"       // needed for websockets support
+#else
+      #include "hwcrypto/sha.h"       // needed for websockets support
+#endif
+
   #include "mbedtls/base64.h"     // needed for websockets support
 
   class WebSocket {  


### PR DESCRIPTION
Add support of esp32 2.0.0 and few minor improvements.
About esp32 2.0.0, if based on IDF 4.4.0 or over then:
* #include "esp32/sha.h" instead of #include "hwcrypto/sha.h"  
* Add new function inet_ntos() 